### PR TITLE
Added logging functionality

### DIFF
--- a/create_icni2_workload.sh
+++ b/create_icni2_workload.sh
@@ -88,14 +88,13 @@ token=$(oc sa get-token -n openshift-monitoring prometheus-k8s)
 
 popd
 
+mkdir -p logs
+
 echo "Lets create SPK pods.."
-kube-burner init -c workload/cfg_icni2_serving_resource_init.yml -t ${token} --uuid 1234
+unbuffer kube-burner init -c workload/cfg_icni2_serving_resource_init.yml -t ${token} --uuid 1234 2>&1 | tee logs/icni2_serving_resource_init_`date +'%Y%m%d%H%M'`.log
 
 echo "Pausing for a minute.."
 sleep 60 # sleep for a minute before actual workload
 
-
 echo "Lets create ICNI2 workloads..$uuid"
-kube-burner init -c ${1} -t ${token} --uuid $(uuidgen) --prometheus-url https://${prometheus_url} -m workload/metrics_full.yaml 
-
-
+unbuffer kube-burner init -c ${1} -t ${token} --uuid $(uuidgen) --prometheus-url https://${prometheus_url} -m workload/metrics_full.yaml 2>&1 | tee logs/icni2_${1}_`date +'%Y%m%d%H%M'`.log


### PR DESCRIPTION
I think it would be handy to have logging functionality for the following reasons:
 - the tmux buffer is too small for recording the whole experiment
 - for tshooting issues with kube-burner, missing metrics, etc.
 - i would like to introduce a metrics function, to be called before and after kube-burner execution with all the relevant metrics that are not obtainable via prometheus (i.e.: relevant OVN leader elections)