### PR TITLE
Simplify node-density

### DIFF
--- a/objectTemplates/cluster_density_dep_served_f5.yml
+++ b/objectTemplates/cluster_density_dep_served_f5.yml
@@ -8,7 +8,7 @@ spec:
     metadata:
       name: pod-served-f5-{{ .Iteration }}-{{ .Replica }}-{{.JobName }}
       labels:
-        app: f5-f5-served-ns-{{ .ns }}-{{ .Replica }}
+        app: f5-f5-served-ns-{{ .Iteration }}-{{ .Replica }}
     spec:
       containers:
       - name: sleep-1
@@ -21,7 +21,7 @@ spec:
           limit:
             memory: '100Mi'
             cpu: 100m
-      - name: f5-f5-served-ns-{{ .ns }}-{{ .Replica }}
+      - name: f5-f5-served-ns-{{ .Iteration }}-{{ .Replica }}
         imagePullPolicy: IfNotPresent
         image: rhscl/httpd-24-rhel7:latest
         ports:
@@ -36,13 +36,13 @@ spec:
             cpu: 100m
         env:
         - name: service_name
-          value: f5-f5-served-ns-{{ .ns }}-{{ .Replica }}
+          value: f5-f5-served-ns-{{ .Iteration }}-{{ .Replica }}
             #  nodeSelector:
             #     kubernetes.io/hostname: worker{{if eq .Iteration 81}}{{printf "%03d" (add .Iteration 2)}}{{else if eq .Iteration 82}}{{printf "%03d" (add .Iteration 1)}}{{else if eq .Iteration 98}}{{printf "%03d" (add .Iteration 2)}}{{else if eq .Iteration 110}}{{printf "%03d" (add .Iteration 2)}}{{else}}{{printf "%03d" (add .Iteration 3)}}{{end}}-r640       
   replicas: 1
   selector:
     matchLabels:
-     app: f5-f5-served-ns-{{ .ns }}-{{ .Replica }}
+     app: f5-f5-served-ns-{{ .Iteration }}-{{ .Replica }}
   triggers:
   - type: ConfigChange
   strategy:

--- a/objectTemplates/cluster_density_pod_service_f5.yml
+++ b/objectTemplates/cluster_density_pod_service_f5.yml
@@ -2,17 +2,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: f5-f5-served-ns-{{ .ns }}-{{ .Replica }}
+  name: f5-f5-served-ns-{{ .Iteration }}-{{ .Replica }}
   labels:
-    app: f5-f5-served-ns-{{ .ns }}-{{ .Replica }}
-    cis.f5.com/as3-tenant: f5-served-ns-{{ .ns }}
-    cis.f5.com/as3-app: f5-f5-served-ns-{{ .ns }}-{{ .Replica }}
+    app: f5-f5-served-ns-{{ .Iteration }}-{{ .Replica }}
+    cis.f5.com/as3-tenant: f5-served-ns-{{ .Iteration }}
+    cis.f5.com/as3-app: f5-f5-served-ns-{{ .Iteration }}-{{ .Replica }}
     cis.f5.com/as3-pool: web_pool
 spec:
   ports:
-  - name: f5-f5-served-ns-{{ .ns }}-{{ .Replica }}
+  - name: f5-f5-served-ns-{{ .Iteration }}-{{ .Replica }}
     port: 8080
     protocol: TCP
     targetPort: 8080
   selector:
-    app: f5-f5-served-ns-{{ .ns }}-{{ .Replica }}
+    app: f5-f5-served-ns-{{ .Iteration }}-{{ .Replica }}

--- a/objectTemplates/node_density_pod_served.yml
+++ b/objectTemplates/node_density_pod_served.yml
@@ -2,10 +2,9 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: pod-served-{{ .Iteration }}-{{ .Replica }}-{{.JobName }}
+  name: pod-served-{{ .Replica }}
   labels:
-    app: pod-served-{{ .Iteration }}
-    ns: served-ns-{{ .Iteration }}-{{ .Replica }}
+    app: pod-served
 spec:
   containers:
   - name: perfapp-1

--- a/objectTemplates/node_density_pod_served.yml
+++ b/objectTemplates/node_density_pod_served.yml
@@ -5,6 +5,7 @@ metadata:
   name: pod-served-{{ .Replica }}
   labels:
     app: pod-served
+    ns: served-ns-{{.Replica}}
 spec:
   containers:
   - name: perfapp-1

--- a/objectTemplates/node_density_pod_served_f5.yml
+++ b/objectTemplates/node_density_pod_served_f5.yml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: pod-served-{{ .Iteration }}-{{ .Replica }}-{{.JobName }}
+  name: pod-served-{{ .Iteration }}-{{ .Replica }}
   labels:
     app: f5-f5-served-ns-{{ .ns }}-{{ .Replica }}
 spec:

--- a/objectTemplates/node_density_pod_service.yml
+++ b/objectTemplates/node_density_pod_service.yml
@@ -9,4 +9,4 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    ns: served-ns-{{ .Iteration }}-{{ .Replica }}
+    ns: served-ns-{{ .Replica }}

--- a/objectTemplates/node_density_pod_service_served.yml
+++ b/objectTemplates/node_density_pod_service_served.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: service-{{ .Iteration }}-{{ .Replica }}
+  name: node-density
 spec:
   ports:
   - name: http
@@ -9,4 +9,4 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    app: pod-served-{{ .Iteration }}
+    app: pod-served

--- a/workload/cfg_icni1_f5_node_density.yml
+++ b/workload/cfg_icni1_f5_node_density.yml
@@ -14,8 +14,6 @@ global:
     type: elastic
 
 jobs:
-
-jobs:
   - name: node-density
     jobType: create
     jobIterations: 33
@@ -35,7 +33,7 @@ jobs:
         replicas: 60
 
 
-  - name: f5-job
+  - name: icni1
     jobType: create
     jobIterations: 35
     qps: {{ .QPS }}

--- a/workload/cfg_icni1_f5_node_density.yml
+++ b/workload/cfg_icni1_f5_node_density.yml
@@ -14,111 +14,40 @@ global:
     type: elastic
 
 jobs:
-{{ range $index, $val := sequence 1 33 }}
-  - name: service-job-{{ $val }}
+
+jobs:
+  - name: node-density
     jobType: create
-    jobIterations: 1
-    qps: 20
-    burst: 20
-    namespacedIterations: false
+    jobIterations: 33
+    qps: {{ .QPS }}
+    burst: {{ .BURST }}
+    namespacedIterations: true
     cleanup: false
-    namespace: f5-served-ns-{{ $val }}
+    namespace: f5-served-ns
     podWait: false
-    waitWhenFinished: false
-    waitFor: ["Pod"]
     verifyObjects: true
-    errorOnVerify: false
-    jobIterationDelay: 0s
-    jobPause: 0s
+    errorOnVerify: true
     objects:
       - objectTemplate: objectTemplates/node_density_pod_service_served.yml
         replicas: 1
-{{ end }}
 
-{{ range $index, $val := sequence 1 33}}
-  - name: normal-job-{{ $val }}
-    jobType: create
-    jobIterations: 1
-    qps: 20
-    burst: 20
-    namespacedIterations: false
-    cleanup: false
-    namespace: f5-served-ns-{{ $val }}
-    podWait: false
-    waitWhenFinished: false
-    waitFor: ["Pod"]
-    verifyObjects: true
-    errorOnVerify: true
-    jobIterationDelay: 0s
-    jobPause: 20s
-    objects:
       - objectTemplate: objectTemplates/node_density_pod_served.yml
         replicas: 60
-{{ end }}
 
-{{ range $index, $val := sequence 1 35 }}
-  - name: service-job-2-{{ $val }}
+
+  - name: f5-job
     jobType: create
-    jobIterations: 1
-    qps: 20
-    burst: 20
-    namespacedIterations: false
+    jobIterations: 35
+    qps: {{ .QPS }}
+    burst: {{ .QPS }}
+    namespacedIterations: true
     cleanup: false
-    namespace: f5-served-ns-{{ $val }}
-    podWait: false
-    waitWhenFinished: false
-    waitFor: ["Pod"]
+    namespace: f5-served-ns
+    podWait: true
     verifyObjects: true
     errorOnVerify: false
-    jobIterationDelay: 0s
-    jobPause: 0s
     objects:
       - objectTemplate: objectTemplates/node_density_pod_service_f5.yml
         replicas: 3
-        inputVars:
-          ns: {{ $val }}
-{{ end }}
-
-{{ range $index, $val := sequence 1 34 }}
-  - name: served-job-{{ $val }}
-    jobType: create
-    jobIterations: 1
-    qps: 20
-    burst: 20
-    namespacedIterations: false
-    cleanup: false
-    namespace: f5-served-ns-{{ $val }}
-    podWait: false
-    waitWhenFinished: false
-    waitFor: ["Pod"]
-    verifyObjects: true
-    errorOnVerify: false
-    jobIterationDelay: 0s
-    jobPause: 5s
-    objects:
       - objectTemplate: objectTemplates/node_density_pod_served_f5.yml
         replicas: 3
-        inputVars:
-          ns: {{ $val }}
-{{ end }}
-
-  - name: served-job-35
-    jobType: create
-    jobIterations: 1
-    qps: 20
-    burst: 20
-    namespacedIterations: false
-    cleanup: false
-    namespace: f5-served-ns-35
-    podWait: false
-    waitWhenFinished: true
-    waitFor: ["Pod"]
-    verifyObjects: true
-    errorOnVerify: false
-    jobIterationDelay: 0s
-    jobPause: 0s
-    objects:
-      - objectTemplate: objectTemplates/node_density_pod_served_f5.yml
-        replicas: 3
-        inputVars:
-          ns: 35

--- a/workload/cfg_icni2_node_density2.yml
+++ b/workload/cfg_icni2_node_density2.yml
@@ -22,7 +22,7 @@ jobs:
     namespacedIterations: true
     cleanup: false
     namespace: served-ns
-    waitWhenFinished: true
+    podWait: true
     verifyObjects: true
     errorOnVerify: true
     objects:

--- a/workload/cfg_icni2_node_density2.yml
+++ b/workload/cfg_icni2_node_density2.yml
@@ -14,110 +14,20 @@ global:
     type: elastic
 
 jobs:
-{{ $normalLimit := multiply 35 .SCALE }}
-{{ range $index, $val := sequence 1 $normalLimit }}
-  - name: normal-service-job-{{ $val }}
+  - name: node-density
     jobType: create
-    jobIterations: 1
+    jobIterations: {{ multiply 35 .SCALE }}
     qps: {{ $.QPS }}
     burst: {{ $.BURST }}
-    namespacedIterations: false
+    namespacedIterations: true
     cleanup: false
-    namespace: served-ns-{{ $val }}
-    podWait: false
-    waitWhenFinished: false
-    waitFor: ["Pod"]
-    verifyObjects: true
-    errorOnVerify: false
-    jobIterationDelay: 0s
-    jobPause: 0s
-    objects:
-      - objectTemplate: objectTemplates/node_density_pod_service_served.yml
-        replicas: 1
-{{ end }}
-
-{{ range $index, $val := sequence 1 $normalLimit}}
-  - name: normal-job-{{ $val }}
-    jobType: create
-    jobIterations: 1
-    qps:  {{ $.QPS }}
-    burst: {{ $.BURST }}
-    namespacedIterations: false
-    cleanup: false
-    namespace: served-ns-{{ $val }}
-    podWait: false
+    namespace: served-ns
     waitWhenFinished: true
-    waitFor: ["Pod"]
     verifyObjects: true
     errorOnVerify: true
-    jobIterationDelay: 0s
-    jobPause: 0s
-    objects:
-      - objectTemplate: objectTemplates/node_density_pod_served.yml
-        replicas: 60
-{{ end }}
-
-{{ $servedLimit := multiply 35 .SCALE }}
-{{ range $index, $val := sequence 1 $servedLimit }}
-  - name: served-service-job-{{ $val }}
-    jobType: create
-    jobIterations: 1
-    qps: {{ $.QPS }}
-    burst: {{ $.BURST }}
-    namespacedIterations: false
-    cleanup: false
-    namespace: served-ns-{{ $val }}
-    podWait: false
-    waitWhenFinished: false
-    waitFor: ["Pod"]
-    verifyObjects: true
-    errorOnVerify: false
-    jobIterationDelay: 0s
-    jobPause: 0s
     objects:
       - objectTemplate: objectTemplates/node_density_pod_service_served.yml
         replicas: 1
-{{ end }}
 
-{{ $lastLimit := add $servedLimit -1 }}
-{{ range $index, $val := sequence 1 $lastLimit }}
-  - name: served-job-{{ $val }}
-    jobType: create
-    jobIterations: 1
-    qps: {{ $.QPS }}
-    burst: {{ $.BURST }}
-    namespacedIterations: false
-    cleanup: false
-    namespace: served-ns-{{ $val }}
-    podWait: false
-    waitWhenFinished: true
-    waitFor: ["Pod"]
-    verifyObjects: true
-    errorOnVerify: false
-    jobIterationDelay: 0s
-    jobPause: 0s
-    objects:
       - objectTemplate: objectTemplates/node_density_pod_served.yml
-        replicas: 3
-{{ end }}
-
-
-  - name: served-job-{{ $servedLimit }}
-    jobType: create
-    jobIterations: 1
-    qps: {{ .QPS }}
-    burst: {{ .BURST }}
-    namespacedIterations: false
-    cleanup: false
-    namespace: served-ns-{{ $servedLimit }}
-    podWait: false
-    waitWhenFinished: true
-    waitFor: ["Pod"]
-    verifyObjects: true
-    errorOnVerify: false
-    jobIterationDelay: 0s
-    jobPause: 0s
-    objects:
-      - objectTemplate: objectTemplates/node_density_pod_served.yml
-        replicas: 3
-
+        replicas: 63

--- a/workload/cfg_icni_node_density50-50.yml
+++ b/workload/cfg_icni_node_density50-50.yml
@@ -14,133 +14,54 @@ global:
     type: elastic
 
 jobs:
-{{ range $index, $val := sequence 1 33 }}
-  - name: service-job-{{ $val }}
+  - name: node-density
     jobType: create
-    jobIterations: 1
-    qps: 20
-    burst: 20
-    namespacedIterations: false
+    jobIterations: 33
+    qps: {{ .QPS }}
+    burst: {{ .BURST }}
+    namespacedIterations: true
     cleanup: false
-    namespace: f5-served-ns-{{ $val }}
-    podWait: false
-    waitWhenFinished: false
-    waitFor: ["Pod"]
+    namespace: f5-served-ns
+    podWait: true
     verifyObjects: true
-    errorOnVerify: false
-    jobIterationDelay: 0s
-    jobPause: 0s
+    errorOnVerify: true
     objects:
       - objectTemplate: objectTemplates/node_density_pod_service_served.yml
         replicas: 1
-{{ end }}
-
-{{ range $index, $val := sequence 1 33}}
-  - name: normal-job-{{ $val }}
-    jobType: create
-    jobIterations: 1
-    qps: 20
-    burst: 20
-    namespacedIterations: false
-    cleanup: false
-    namespace: f5-served-ns-{{ $val }}
-    podWait: false
-    waitWhenFinished: true
-    waitFor: ["Pod"]
-    verifyObjects: true
-    errorOnVerify: true
-    jobIterationDelay: 0s
-    jobPause: 0s
-    objects:
       - objectTemplate: objectTemplates/node_density_pod_served.yml
         replicas: 30
-{{ end }}
 
-{{ range $index, $val := sequence 1 35 }}
-  - name: service-job-2-{{ $val }}
+  - name: icni1
     jobType: create
-    jobIterations: 1
-    qps: 20
-    burst: 20
-    namespacedIterations: false
+    jobIterations: 35
+    qps: {{ .QPS }}
+    burst: {{ .QPS }}
+    namespacedIterations: true
     cleanup: false
-    namespace: f5-served-ns-{{ $val }}
-    podWait: false
-    waitWhenFinished: false
-    waitFor: ["Pod"]
+    namespace: f5-served-ns
+    podWait: true
     verifyObjects: true
     errorOnVerify: false
-    jobIterationDelay: 0s
-    jobPause: 0s
     objects:
       - objectTemplate: objectTemplates/node_density_pod_service_f5.yml
         replicas: 3
-        inputVars:
-          ns: {{ $val }}
-{{ end }}
-
-{{ range $index, $val := sequence 1 35 }}
-  - name: served-job-{{ $val }}
-    jobType: create
-    jobIterations: 1
-    qps: 20
-    burst: 20
-    namespacedIterations: false
-    cleanup: false
-    namespace: f5-served-ns-{{ $val }}
-    podWait: false
-    waitWhenFinished: true
-    waitFor: ["Pod"]
-    verifyObjects: true
-    errorOnVerify: false
-    jobIterationDelay: 0s
-    jobPause: 0s
-    objects:
       - objectTemplate: objectTemplates/node_density_pod_served_f5.yml
         replicas: 3
-        inputVars:
-          ns: {{ $val }}
-{{ end }}
 
-{{ $normalLimit := multiply 35 .SCALE }}
-{{ range $index, $val := sequence 1 $normalLimit }}
-  - name: icni2-service-job-{{ $val }}
+  - name: icni2
     jobType: create
-    jobIterations: 1       
+    jobIterations: {{ multiply 35 .SCALE }}
     qps: {{ $.QPS }}
     burst: {{ $.BURST }}
-    namespacedIterations: false
+    namespacedIterations: true
     cleanup: false
-    namespace: served-ns-{{ $val }}
-    podWait: false
-    waitWhenFinished: false
-    waitFor: ["Pod"]
+    namespace: served-ns
+    podWait: true
     verifyObjects: true
-    errorOnVerify: false
-    jobIterationDelay: 0s
-    jobPause: 0s
+    errorOnVerify: true
     objects:
       - objectTemplate: objectTemplates/node_density_pod_service_served.yml
         replicas: 1
-{{ end }}
 
-{{ range $index, $val := sequence 1 $normalLimit}}
-  - name: icni2-served-job-{{ $val }}
-    jobType: create
-    jobIterations: 1
-    qps:  {{ $.QPS }}
-    burst: {{ $.BURST }}
-    namespacedIterations: false
-    cleanup: false
-    namespace: served-ns-{{ $val }}
-    podWait: false
-    waitWhenFinished: true
-    waitFor: ["Pod"]
-    verifyObjects: true
-    errorOnVerify: true
-    jobIterationDelay: 0s
-    jobPause: 0s
-    objects:
       - objectTemplate: objectTemplates/node_density_pod_served.yml
         replicas: 33
-{{ end }}


### PR DESCRIPTION
Simplified version of the ICNI2 node-density workload:

- [x] ICNI2
- [x] ICNI1
- [x] Mixed

It makes use of podWait: true in order to wait for pods to be ready between iterations, that way the generated workload can be compared with the original one.

cc: @josecastillolema @mukrishn @mohit-sheth

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>