### PR TITLE
Add indexing env vars

### DIFF
--- a/create_icni2_workload.sh
+++ b/create_icni2_workload.sh
@@ -8,6 +8,9 @@ export QPS=${QPS:-20}
 export BURST=${BURST:-20}
 export SCALE=${SCALE:-1}
 export BFD=${BFD:-false}
+export INDEXING=${INDEXING:-true}
+export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com}
+export ES_INDEX=${ES_INDEX:-ripsaw-kube-burner}
 
 export vf_serving_factor=140
 num_vfs=$(( SCALE*vf_serving_factor))

--- a/workload/cfg_delete_icni1_f5_cluster_density.yml
+++ b/workload/cfg_delete_icni1_f5_cluster_density.yml
@@ -5,9 +5,9 @@ global:
   metricsDirectory: collected-metrics
   indexerConfig:
     enabled: false
-    esServers: [https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com]
+    esServers: {{ .ES_SERVER }}
     insecureSkipVerify: true
-    defaultIndex: kube-burner
+    defaultIndex: {{ .ES_INDEX }}
     type: elastic
 
 jobs:

--- a/workload/cfg_delete_icni1_f5_node_density.yml
+++ b/workload/cfg_delete_icni1_f5_node_density.yml
@@ -5,9 +5,9 @@ global:
   metricsDirectory: collected-metrics
   indexerConfig:
     enabled: false
-    esServers: [https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com]
+    esServers: {{ .ES_SERVER }}
     insecureSkipVerify: true
-    defaultIndex: kube-burner
+    defaultIndex: {{ .ES_INDEX }}
     type: elastic
 
 jobs:

--- a/workload/cfg_delete_icni2_cluster_density2.yml
+++ b/workload/cfg_delete_icni2_cluster_density2.yml
@@ -5,9 +5,9 @@ global:
   metricsDirectory: collected-metrics
   indexerConfig:
     enabled: false
-    esServers: [https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com]
+    esServers: {{ .ES_SERVER }}
     insecureSkipVerify: true
-    defaultIndex: kube-burner
+    defaultIndex: {{ .ES_INDEX }}
     type: elastic
 
 jobs:

--- a/workload/cfg_delete_icni2_node_density2.yml
+++ b/workload/cfg_delete_icni2_node_density2.yml
@@ -5,9 +5,9 @@ global:
   metricsDirectory: collected-metrics
   indexerConfig:
     enabled: false
-    esServers: [https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com]
+    esServers: {{ .ES_SERVER }}
     insecureSkipVerify: true
-    defaultIndex: kube-burner
+    defaultIndex: {{ .ES_INDEX }}
     type: elastic
 
 jobs:

--- a/workload/cfg_delete_icni2_serving_resource.yml
+++ b/workload/cfg_delete_icni2_serving_resource.yml
@@ -4,9 +4,9 @@ global:
   metricsDirectory: collected-metrics
   indexerConfig:
     enabled: false
-    esServers: [https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com]
+    esServers: {{ .ES_SERVER }}
     insecureSkipVerify: true
-    defaultIndex: kube-burner
+    defaultIndex: {{ .ES_INDEX }}
     type: elastic
 
 jobs:

--- a/workload/cfg_icni1_f5_cluster_density.yml
+++ b/workload/cfg_icni1_f5_cluster_density.yml
@@ -5,12 +5,12 @@ global:
   metricsDirectory: collected-metrics
   measurements:
     - name: podLatency
-      esIndex: kube-burner
+      defaultIndex: {{ .ES_INDEX }}
   indexerConfig:
-    enabled: true
-    esServers: [https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com]
+    enabled: {{ .INDEXING }}
+    esServers: {{ .ES_SERVER }}
     insecureSkipVerify: true
-    defaultIndex: kube-burner
+    defaultIndex: {{ .ES_INDEX }}
     type: elastic
 
 jobs:

--- a/workload/cfg_icni1_f5_node_density.yml
+++ b/workload/cfg_icni1_f5_node_density.yml
@@ -5,12 +5,12 @@ global:
   metricsDirectory: collected-metrics
   measurements:
     - name: podLatency
-      esIndex: kube-burner
+      defaultIndex: {{ .ES_INDEX }}
   indexerConfig:
-    enabled: true
-    esServers: [https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com]
+    enabled: {{ .INDEXING }}
+    esServers: {{ .ES_SERVER }}
     insecureSkipVerify: true
-    defaultIndex: kube-burner
+    defaultIndex: {{ .ES_INDEX }}
     type: elastic
 
 jobs:

--- a/workload/cfg_icni2_cluster_density2.yml
+++ b/workload/cfg_icni2_cluster_density2.yml
@@ -5,12 +5,12 @@ global:
   metricsDirectory: collected-metrics
   measurements:
     - name: podLatency
-      esIndex: kube-burner
+      defaultIndex: {{ .ES_INDEX }}
   indexerConfig:
-    enabled: true
-    esServers: [https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com]
+    enabled: {{ .INDEXING }}
+    esServers: {{ .ES_SERVER }}
     insecureSkipVerify: true
-    defaultIndex: kube-burner
+    defaultIndex: {{ .ES_INDEX }}
     type: elastic
 
 jobs:

--- a/workload/cfg_icni2_node_density2.yml
+++ b/workload/cfg_icni2_node_density2.yml
@@ -5,12 +5,12 @@ global:
   metricsDirectory: collected-metrics
   measurements:
     - name: podLatency
-      esIndex: kube-burner
+      defaultIndex: {{ .ES_INDEX }}
   indexerConfig:
-    enabled: true
-    esServers: [https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com]
+    enabled: {{ .INDEXING }}
+    esServers: {{ .ES_SERVER }}
     insecureSkipVerify: true
-    defaultIndex: kube-burner
+    defaultIndex: {{ .ES_INDEX }}
     type: elastic
 
 jobs:

--- a/workload/cfg_icni2_node_density2_heavy.yml
+++ b/workload/cfg_icni2_node_density2_heavy.yml
@@ -3,12 +3,12 @@ global:
   metricsDirectory: collected-metrics
   measurements:
     - name: podLatency
-      esIndex: kube-burner
+      defaultIndex: {{ .ES_INDEX }}
   indexerConfig:
-    enabled: true
-    esServers: [https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com]
+    enabled: {{ .INDEXING }}
+    esServers: {{ .ES_SERVER }}
     insecureSkipVerify: true
-    defaultIndex: kube-burner
+    defaultIndex: {{ .ES_INDEX }}
     type: elastic
 
 jobs:

--- a/workload/cfg_icni2_serving_resource_init.yml
+++ b/workload/cfg_icni2_serving_resource_init.yml
@@ -4,12 +4,12 @@ global:
   metricsDirectory: collected-metrics
   measurements:
     - name: podLatency
-      esIndex: kube-burner
+      defaultIndex: {{ .ES_INDEX }}
   indexerConfig:
-    enabled: true
-    esServers: [https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com]
+    enabled: {{ .INDEXING }}
+    esServers: {{ .ES_SERVER }}
     insecureSkipVerify: true
-    defaultIndex: kube-burner
+    defaultIndex: {{ .ES_INDEX }}
     type: elastic
 
 jobs:

--- a/workload/cfg_icni_cluster_density50-50.yml
+++ b/workload/cfg_icni_cluster_density50-50.yml
@@ -5,12 +5,12 @@ global:
   metricsDirectory: collected-metrics
   measurements:
     - name: podLatency
-      esIndex: kube-burner
+      defaultIndex: {{ .ES_INDEX }}
   indexerConfig:
-    enabled: true
-    esServers: [http://elastic:62cuyJA229jfFl604nUC54TV@perf-results-elastic.apps.keith-cluster.perfscale.devcluster.openshift.com]
+    enabled: {{ .INDEXING }}
+    esServers: {{ .ES_SERVER }}
     insecureSkipVerify: true
-    defaultIndex: kube-burner
+    defaultIndex: {{ .ES_INDEX }}
     type: elastic
 
 jobs:

--- a/workload/cfg_icni_node_density50-50.yml
+++ b/workload/cfg_icni_node_density50-50.yml
@@ -5,12 +5,12 @@ global:
   metricsDirectory: collected-metrics
   measurements:
     - name: podLatency
-      esIndex: kube-burner
+      defaultIndex: {{ .ES_INDEX }}
   indexerConfig:
-    enabled: true
-    esServers: [https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com]
+    enabled: {{ .INDEXING }}
+    esServers: {{ .ES_SERVER }}
     insecureSkipVerify: true
-    defaultIndex: kube-burner
+    defaultIndex: {{ .ES_INDEX }}
     type: elastic
 
 jobs:

--- a/workload/cfg_regular_cluster_density.yml
+++ b/workload/cfg_regular_cluster_density.yml
@@ -5,12 +5,12 @@ global:
   metricsDirectory: collected-metrics
   measurements:
     - name: podLatency
-      esIndex: kube-burner
+      defaultIndex: {{ .ES_INDEX }}
   indexerConfig:
-    enabled: true
-    esServers: [https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com]
+    enabled: {{ .INDEXING }}
+    esServers: {{ .ES_SERVER }}
     insecureSkipVerify: true
-    defaultIndex: kube-burner
+    defaultIndex: {{ .ES_INDEX }}
     type: elastic
 
 jobs:

--- a/workload/cfg_regular_node_density.yml
+++ b/workload/cfg_regular_node_density.yml
@@ -5,12 +5,12 @@ global:
   metricsDirectory: collected-metrics
   measurements:
     - name: podLatency
-      esIndex: kube-burner
+      defaultIndex: {{ .ES_INDEX }}
   indexerConfig:
-    enabled: true
-    esServers: [https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com]
+    enabled: {{ .INDEXING }}
+    esServers: {{ .ES_SERVER }}
     insecureSkipVerify: true
-    defaultIndex: kube-burner
+    defaultIndex: {{ .ES_INDEX }}
     type: elastic
 
 jobs:


### PR DESCRIPTION
Add indexing related env vars in order to make ES indexing more configurable from the command line.

cc: @mukrishn @josecastillolema @smalleni 

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>