### PR TITLE
Update token fetch expression

### DIFF
--- a/create_icni2_workload.sh
+++ b/create_icni2_workload.sh
@@ -84,7 +84,7 @@ done
 
 echo "Set Openshift monitoring vars.."
 prometheus_url=$(oc get routes -n openshift-monitoring prometheus-k8s --no-headers | awk '{print $2}')
-token=$(oc sa get-token -n openshift-monitoring prometheus-k8s)
+token=$(oc create token -n openshift-monitoring prometheus-k8s --duration=6h || oc sa new-token -n openshift-monitoring prometheus-k8s)
 
 popd
 


### PR DESCRIPTION
The get-token expression is deprecated:

```
[root@e16-h12-b02-fc640 web-burner]# oc sa get-token -n openshift-monitoring prometheus-k8s                                                                                                                                                   
Command "get-token" is deprecated, and will be removed in the future version. Use oc create token instead.             
error: could not find a service account token for service account "prometheus-k8s"       
```


Signed-off-by: Raul Sevilla <rsevilla@redhat.com>