### PR TITLE
Fix the no-BFD scenario (again)

### DIFF
--- a/objectTemplates/pod_serving_no_bfd.yml
+++ b/objectTemplates/pod_serving_no_bfd.yml
@@ -13,7 +13,6 @@ spec:
         gateway-ip: "192.168.{{ add 218 .Replica }}.{{ .Iteration }}"
         k8s.ovn.org/routing-namespaces: served-ns-{{ .Iteration }}
         k8s.ovn.org/routing-network: serving-ns-{{ .Iteration }}/sriov-net-{{ .Iteration }}
-        k8s.ovn.org/bfd-enabled: "false"
         k8s.v1.cni.cncf.io/networks: |-
           [{ "name": "sriov-net-{{ .Iteration }}", "ips": [ "192.168.{{ add 218 .Replica }}.{{ .Iteration }}/21" ]}]
         k8s.v1.cni.cncf.io/network-status: |-


### PR DESCRIPTION
This adjusment was not working:
```
k8s.ovn.org/bfd-enabled: "false"
```

As long as there is a k8s.ovn.org/bfd-enabled property BFD will be enabled.

The correct way to disable BFD is to completely remove the line.