### PR TITLE
Allow passing the limit count value dynamically as an Environment variable

### DIFF
--- a/create_icni2_workload.sh
+++ b/create_icni2_workload.sh
@@ -11,6 +11,8 @@ export BFD=${BFD:-false}
 export INDEXING=${INDEXING:-true}
 export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com}
 export ES_INDEX=${ES_INDEX:-ripsaw-kube-burner}
+#The limit count is used to calculate servedlimit and normallimit. For a 120 node cluster the default count is 35, for other size clusters use this formula to calculate. limit count = (35 * cluster_size) // 120
+export LIMITCOUNT=${LIMITCOUNT:-35} 
 
 export vf_serving_factor=140
 num_vfs=$(( SCALE*vf_serving_factor))

--- a/delete_icni_workload.sh
+++ b/delete_icni_workload.sh
@@ -8,6 +8,8 @@ export QPS=${QPS:-20}
 export BURST=${BURST:-20}
 export SCALE=${SCALE:-1}
 export BFD=${BFD:-false}
+#The limit count is used to calculate servedlimit and normallimit. For a 120 node cluster the default count is 35, for other size clusters use this formula to calculate. limit count = (35 * cluster_size) // 120
+export LIMITCOUNT=${LIMITCOUNT:-35} 
 
 kube_burner_exists=$(which kube-burner)
 

--- a/workload/cfg_delete_icni1_f5_cluster_density.yml
+++ b/workload/cfg_delete_icni1_f5_cluster_density.yml
@@ -12,7 +12,7 @@ global:
 
 jobs:
         
-{{ $servedLimit := multiply 35 .SCALE }}
+{{ $servedLimit := multiply .LIMITCOUNT .SCALE }}
 {{ range $index, $val := sequence 1 $servedLimit }}
   - name: delete-job-{{ $val }}
     jobType: delete

--- a/workload/cfg_delete_icni1_f5_node_density.yml
+++ b/workload/cfg_delete_icni1_f5_node_density.yml
@@ -11,7 +11,7 @@ global:
     type: elastic
 
 jobs:
-{{ $normalLimit := multiply 35 .SCALE }}
+{{ $normalLimit := multiply .LIMITCOUNT .SCALE }}
 {{ range $index, $val := sequence 1 $normalLimit }}
   - name: delete-service-job-{{ $val }}
     jobType: delete

--- a/workload/cfg_delete_icni2_cluster_density2.yml
+++ b/workload/cfg_delete_icni2_cluster_density2.yml
@@ -11,7 +11,7 @@ global:
     type: elastic
 
 jobs:
-{{ $servedLimit := multiply 35 .SCALE }}
+{{ $servedLimit := multiply .LIMITCOUNT .SCALE }}
   - name: delete-jobs
     jobType: delete
     qps: {{ .QPS }}

--- a/workload/cfg_delete_icni2_node_density2.yml
+++ b/workload/cfg_delete_icni2_node_density2.yml
@@ -11,7 +11,7 @@ global:
     type: elastic
 
 jobs:
-{{ $normalLimit := multiply 35 .SCALE }}
+{{ $normalLimit := multiply .LIMITCOUNT .SCALE }}
 {{ range $index, $val := sequence 1 $normalLimit }}
   - name: delete-service-job-{{ $val }}
     jobType: delete

--- a/workload/cfg_icni1_f5_cluster_density.yml
+++ b/workload/cfg_icni1_f5_cluster_density.yml
@@ -27,7 +27,7 @@ jobs:
   #   - kind: Pod
   #     labelSelector: {kube-burner-job: init-job}
         
-{{ $normalLimit := multiply 35 .SCALE }}
+{{ $normalLimit := multiply .LIMITCOUNT .SCALE }}
 {{ range $index, $val := sequence 1 $normalLimit }}
   - name: job-{{ $val }}
     jobType: create

--- a/workload/cfg_icni2_cluster_density2.yml
+++ b/workload/cfg_icni2_cluster_density2.yml
@@ -16,7 +16,7 @@ global:
 jobs:
   - name: cluster-density
     jobType: create
-    jobIterations: {{ multiply 35 .SCALE }}
+    jobIterations: {{ multiply .LIMITCOUNT .SCALE }}
     qps: {{ $.QPS }}
     burst: {{ $.BURST }}
     namespacedIterations: true

--- a/workload/cfg_icni2_node_density2.yml
+++ b/workload/cfg_icni2_node_density2.yml
@@ -14,7 +14,7 @@ global:
     type: elastic
 
 jobs:
-{{ $normalLimit := multiply 35 .SCALE }}
+{{ $normalLimit := multiply .LIMITCOUNT .SCALE }}
 {{ range $index, $val := sequence 1 $normalLimit }}
   - name: normal-service-job-{{ $val }}
     jobType: create
@@ -57,7 +57,7 @@ jobs:
         replicas: 60
 {{ end }}
 
-{{ $servedLimit := multiply 35 .SCALE }}
+{{ $servedLimit := multiply .LIMITCOUNT .SCALE }}
 {{ range $index, $val := sequence 1 $servedLimit }}
   - name: served-service-job-{{ $val }}
     jobType: create

--- a/workload/cfg_icni2_node_density2_heavy.yml
+++ b/workload/cfg_icni2_node_density2_heavy.yml
@@ -12,7 +12,7 @@ global:
     type: elastic
 
 jobs:
-{{ $servedLimit := multiply 35 .SCALE }}
+{{ $servedLimit := multiply .LIMITCOUNT .SCALE }}
 {{ range $index, $val := sequence 1 $servedLimit }}
   - name: kubelet-density-heavy-{{ $val }}
     jobIterations: 1

--- a/workload/cfg_icni2_serving_resource_init.yml
+++ b/workload/cfg_icni2_serving_resource_init.yml
@@ -16,7 +16,7 @@ jobs:
        
   - name: init-job
     jobType: create
-    jobIterations: {{ multiply 35 .SCALE }}
+    jobIterations: {{ multiply .LIMITCOUNT .SCALE }}
     qps: 20
     burst: 20
     namespacedIterations: true
@@ -36,7 +36,7 @@ jobs:
 
   - name: create-networks-job
     jobType: create
-    jobIterations: {{ multiply 35 .SCALE }}
+    jobIterations: {{ multiply .LIMITCOUNT .SCALE }}
     qps: 10
     burst: 10
     namespacedIterations: false
@@ -55,7 +55,7 @@ jobs:
 
   - name: create-cms-job
     jobType: create
-    jobIterations: {{ multiply 35 .SCALE }}
+    jobIterations: {{ multiply .LIMITCOUNT .SCALE }}
     qps: 20
     burst: 20
     namespacedIterations: true
@@ -74,7 +74,7 @@ jobs:
 
   - name: create-secrets-job
     jobType: create
-    jobIterations: {{ multiply 35 .SCALE }}
+    jobIterations: {{ multiply .LIMITCOUNT .SCALE }}
     qps: 20
     burst: 20
     namespacedIterations: true
@@ -93,7 +93,7 @@ jobs:
 
   - name: init-served-job
     jobType: create
-    jobIterations: {{ multiply 35 .SCALE }}
+    jobIterations: {{ multiply .LIMITCOUNT .SCALE }}
     qps: 20
     burst: 20
     namespacedIterations: true
@@ -112,7 +112,7 @@ jobs:
 
   - name: serving-job
     jobType: create
-    jobIterations: {{ multiply 35 .SCALE }}
+    jobIterations: {{ multiply .LIMITCOUNT .SCALE }}
     qps: 20
     burst: 20
     namespacedIterations: true

--- a/workload/cfg_icni_cluster_density50-50.yml
+++ b/workload/cfg_icni_cluster_density50-50.yml
@@ -15,7 +15,7 @@ global:
 
 jobs:
 
-{{ $normalLimit := multiply 35 .SCALE }}
+{{ $normalLimit := multiply .LIMITCOUNT .SCALE }}
 {{ range $index, $val := sequence 1 $normalLimit }}
   - name: job-{{ $val }}
     jobType: create
@@ -247,7 +247,7 @@ jobs:
           ns: group-l-{{ $val }}                   
 {{ end }}
         
-{{ $servedLimit := multiply 35 .SCALE }}
+{{ $servedLimit := multiply .LIMITCOUNT .SCALE }}
 {{ range $index, $val := sequence 1 $servedLimit }}
   - name: job-2-{{ $val }}
     jobType: create

--- a/workload/cfg_icni_node_density50-50.yml
+++ b/workload/cfg_icni_node_density50-50.yml
@@ -102,7 +102,7 @@ jobs:
           ns: {{ $val }}
 {{ end }}
 
-{{ $normalLimit := multiply 35 .SCALE }}
+{{ $normalLimit := multiply .LIMITCOUNT .SCALE }}
 {{ range $index, $val := sequence 1 $normalLimit }}
   - name: icni2-service-job-{{ $val }}
     jobType: create


### PR DESCRIPTION
This PR Modifies the hard coded limit count(35) value and allows it to be set dynamically at run time as an environment variable. The default is still 35 which is used when the cluster size is 120 nodes / verizon test cases. 