### PR TITLE
Revert "Removed unused pod_served.yml file"

### DIFF
--- a/objectTemplates/pod_served.yml
+++ b/objectTemplates/pod_served.yml
@@ -1,0 +1,35 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:    
+  name: dep-served-init-{{ .Iteration }}-{{ .Replica }}-{{.JobName }}
+spec:
+  template:
+    metadata:
+      name: pod-served-{{ .Iteration }}-{{ .Replica }}-{{.JobName }}
+      labels:
+        app: served-init-{{ .Iteration }}-{{ .Replica }}-{{.JobName }}
+    spec:
+      containers:
+      - args:
+        - sleep
+        - infinity
+        name: app
+        image: k8s.gcr.io/pause:3.1
+        ports:
+        - containerPort: 80
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: worker-spk
+                operator: DoesNotExist
+  replicas: 1
+  selector:
+    matchLabels:
+     app: served-init-{{ .Iteration }}-{{ .Replica }}-{{.JobName }}
+  triggers:
+  - type: ConfigChange
+  strategy:
+    type: RollingUpdate 


### PR DESCRIPTION
Reverts redhat-performance/web-burner#48

Missed a use of pod_served.yml in https://github.com/redhat-performance/web-burner/blob/main/workload/cfg_icni2_serving_resource_init.yml#L110