### PR TITLE
Affinity

### DIFF
--- a/objectTemplates/cluster_density_dep_served.yml
+++ b/objectTemplates/cluster_density_dep_served.yml
@@ -36,6 +36,13 @@ spec:
           limits:
             memory: '100Mi'
             cpu: 100m
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker-spk
+                operator: DoesNotExist
   replicas: 2
   selector:
     matchLabels:

--- a/objectTemplates/cluster_density_pod_served.yml
+++ b/objectTemplates/cluster_density_pod_served.yml
@@ -35,4 +35,10 @@ spec:
       value: app-served-{{ .ns }}
         #  nodeSelector:
         #     kubernetes.io/hostname: worker{{if eq .Iteration 81}}{{printf "%03d" (add .Iteration 2)}}{{else if eq .Iteration 82}}{{printf "%03d" (add .Iteration 1)}}{{else if eq .Iteration 98}}{{printf "%03d" (add .Iteration 2)}}{{else if eq .Iteration 110}}{{printf "%03d" (add .Iteration 2)}}{{else}}{{printf "%03d" (add .Iteration 3)}}{{end}}-r640       
-     
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: node-role.kubernetes.io/worker-spk
+            operator: DoesNotExist   

--- a/objectTemplates/node_density_pod_served.yml
+++ b/objectTemplates/node_density_pod_served.yml
@@ -40,8 +40,13 @@ spec:
         cpu: 100m
       limit:
         memory: '100Mi'
-        cpu: 100m    
+        cpu: 100m   
       #  nodeSelector:
       #     kubernetes.io/hostname: worker{{if eq .Iteration 81}}{{printf "%03d" (add .Iteration 2)}}{{else if eq .Iteration 82}}{{printf "%03d" (add .Iteration 1)}}{{else if eq .Iteration 98}}{{printf "%03d" (add .Iteration 2)}}{{else if eq .Iteration 110}}{{printf "%03d" (add .Iteration 2)}}{{else}}{{printf "%03d" (add .Iteration 3)}}{{end}}-r640   
-     
-     
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: node-role.kubernetes.io/worker-spk
+            operator: DoesNotExist

--- a/objectTemplates/pod_served.yml
+++ b/objectTemplates/pod_served.yml
@@ -23,7 +23,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: worker-spk
+              - key: node-role.kubernetes.io/worker-spk
                 operator: DoesNotExist
   replicas: 1
   selector:


### PR DESCRIPTION
Current pod affinity label is not correct and causes some app pods to be scheduled on lb nodes:
```
            - matchExpressions:
              - key: worker-spk
                operator: DoesNotExist
```

On top of that, **node_density_pod_served.yml**, **cluster_density_pod_served.yml** and **cluster_density_dep_served.yml** were missing the affinity annotation.