### PR TITLE
Macvlan network attachment definitions support

### DIFF
--- a/create_icni2_workload.sh
+++ b/create_icni2_workload.sh
@@ -3,11 +3,12 @@
 SCALE=$2
 BFD=$3
 
-export KUBE_BURNER_RELEASE=${KUBE_BURNER_RELEASE:-1.3}
+export KUBE_BURNER_RELEASE=${KUBE_BURNER_RELEASE:-1.7}
 export QPS=${QPS:-20}
 export BURST=${BURST:-20}
 export SCALE=${SCALE:-1}
 export BFD=${BFD:-false}
+export SRIOV=${SRIOV:-true}
 export INDEXING=${INDEXING:-true}
 export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com}
 export ES_INDEX=${ES_INDEX:-ripsaw-kube-burner}

--- a/objectTemplates/macvlan_network.yml
+++ b/objectTemplates/macvlan_network.yml
@@ -1,0 +1,27 @@
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-net-{{ .Iteration }}
+spec:
+  config: |-
+    {
+      "cniVersion": "0.3.1",
+      "name": "internal-net",
+      "plugins": [
+        {
+          "type": "macvlan",
+          "master": "breth0",
+          "mode": "bridge",
+          "ipam": {
+            "type": "static"
+          }
+        },
+        {
+          "capabilities": {
+            "mac": true,
+            "ips": true
+          },
+          "type": "tuning"
+        }
+      ]
+    }

--- a/workload/cfg_icni2_serving_resource_init.yml
+++ b/workload/cfg_icni2_serving_resource_init.yml
@@ -1,10 +1,7 @@
 ---
 global:
-  writeToFile: true
-  metricsDirectory: collected-metrics
   measurements:
     - name: podLatency
-      esIndex: {{ .ES_INDEX }}
   indexerConfig:
     enabled: {{ .INDEXING }}
     esServers: ["{{.ES_SERVER}}"]
@@ -16,7 +13,7 @@ jobs:
        
   - name: init-job
     jobType: create
-    jobIterations: {{ multiply .LIMITCOUNT .SCALE }}
+    jobIterations: {{ mul .LIMITCOUNT .SCALE }}
     qps: 20
     burst: 20
     namespacedIterations: true
@@ -24,7 +21,6 @@ jobs:
     namespace: serving-ns
     podWait: false
     waitWhenFinished: true
-    waitFor: ["Pod"]
     verifyObjects: true
     errorOnVerify: true
     jobIterationDelay: 0s
@@ -36,27 +32,26 @@ jobs:
 
   - name: create-networks-job
     jobType: create
-    jobIterations: {{ multiply .LIMITCOUNT .SCALE }}
+    jobIterations: {{ mul .LIMITCOUNT .SCALE }}
     qps: 10
     burst: 10
-    namespacedIterations: false
+    namespacedIterations: {{ if contains .SRIOV "true" }} false {{ else }} true {{ end }}
     cleanup: false
-    namespace: openshift-sriov-network-operator
+    namespace: {{ if contains .SRIOV "true" }} openshift-sriov-network-operator {{ else }} serving-ns {{ end }}
     podWait: false
     waitWhenFinished: false
-    waitFor: ["net-attach-def"]
     verifyObjects: true
     errorOnVerify: false
     jobIterationDelay: 1s
     jobPause: 0s
     preLoadImages: false
     objects:
-      - objectTemplate: objectTemplates/sriov_network.yml
+      - objectTemplate: {{ if contains .SRIOV "true" }} objectTemplates/sriov_network.yml {{ else }} objectTemplates/macvlan_network.yml {{ end }}
         replicas: 1
 
   - name: create-serviceaccounts-job
     jobType: create
-    jobIterations: {{ multiply .LIMITCOUNT .SCALE }}
+    jobIterations: {{ mul .LIMITCOUNT .SCALE }}
     qps: 20
     burst: 20
     namespacedIterations: true
@@ -64,7 +59,6 @@ jobs:
     namespace: serving-ns
     podWait: false
     waitWhenFinished: false
-    waitFor: ["ServiceAccount"]
     verifyObjects: true
     errorOnVerify: false
     jobIterationDelay: 1s
@@ -96,7 +90,7 @@ jobs:
 
   - name: create-clusterbindings-jobs
     jobType: create
-    jobIterations: {{ multiply .LIMITCOUNT .SCALE }}
+    jobIterations: {{ mul .LIMITCOUNT .SCALE }}
     qps: 20
     burst: 20
     namespacedIterations: true
@@ -104,7 +98,6 @@ jobs:
     namespace: serving-ns
     podWait: false
     waitWhenFinished: false
-    waitFor: ["ClusterRoleBinding"]
     verifyObjects: true
     errorOnVerify: false
     jobIterationDelay: 1s
@@ -117,7 +110,7 @@ jobs:
 
   - name: create-cms-job
     jobType: create
-    jobIterations: {{ multiply .LIMITCOUNT .SCALE }}
+    jobIterations: {{ mul .LIMITCOUNT .SCALE }}
     qps: 20
     burst: 20
     namespacedIterations: true
@@ -125,7 +118,6 @@ jobs:
     namespace: serving-ns
     podWait: false
     waitWhenFinished: false
-    waitFor: ["configMap"]
     verifyObjects: true
     errorOnVerify: false
     jobIterationDelay: 1s
@@ -137,7 +129,7 @@ jobs:
 
   - name: create-secrets-job
     jobType: create
-    jobIterations: {{ multiply .LIMITCOUNT .SCALE }}
+    jobIterations: {{ mul .LIMITCOUNT .SCALE }}
     qps: 20
     burst: 20
     namespacedIterations: true
@@ -145,7 +137,6 @@ jobs:
     namespace: serving-ns
     podWait: false
     waitWhenFinished: false
-    waitFor: ["Secret"]
     verifyObjects: true
     errorOnVerify: false
     jobIterationDelay: 0s
@@ -157,7 +148,7 @@ jobs:
 
   - name: init-served-job
     jobType: create
-    jobIterations: {{ multiply .LIMITCOUNT .SCALE }}
+    jobIterations: {{ mul .LIMITCOUNT .SCALE }}
     qps: 20
     burst: 20
     namespacedIterations: true
@@ -165,7 +156,6 @@ jobs:
     namespace: served-ns
     podWait: false
     waitWhenFinished: true
-    waitFor: ["Deployment"]
     verifyObjects: true
     errorOnVerify: true
     jobIterationDelay: 0s
@@ -177,7 +167,7 @@ jobs:
 
   - name: serving-job
     jobType: create
-    jobIterations: {{ multiply .LIMITCOUNT .SCALE }}
+    jobIterations: {{ mul .LIMITCOUNT .SCALE }}
     qps: 20
     burst: 20
     namespacedIterations: true
@@ -185,7 +175,6 @@ jobs:
     namespace: serving-ns
     podWait: false
     waitWhenFinished: true
-    waitFor: ["Deployment"]
     verifyObjects: true
     errorOnVerify: true
     jobIterationDelay: 0s


### PR DESCRIPTION
https://github.com/redhat-performance/web-burner/pull/56 is a prereq for this PR.

This PR implements macvlan network attachment definitions support making sriov interfaces optional (for clusters where SRIOV is not available, i.e.: local dev machine, CI, cloud).

It bumps kube-burner to v1.7 because of https://github.com/cloud-bulldozer/kube-burner/pull/331.