### PR TITLE
Corrected missnumbering namespaces

### DIFF
--- a/objectTemplates/cluster_density_dep_served_f5.yml
+++ b/objectTemplates/cluster_density_dep_served_f5.yml
@@ -14,13 +14,6 @@ spec:
       - name: sleep-1
         imagePullPolicy: IfNotPresent
         image: gcr.io/google_containers/pause-amd64:3.0
-        resources:
-          request:
-            memory: '100Mi'
-            cpu: 100m
-          limit:
-            memory: '100Mi'
-            cpu: 100m
       - name: f5-f5-served-ns-{{ .ns }}-{{ .Replica }}
         imagePullPolicy: IfNotPresent
         image: rhscl/httpd-24-rhel7:latest

--- a/objectTemplates/cluster_density_dep_served_ports.yml
+++ b/objectTemplates/cluster_density_dep_served_ports.yml
@@ -14,13 +14,6 @@ spec:
       - name: sleep-1
         imagePullPolicy: IfNotPresent
         image: gcr.io/google_containers/pause-amd64:3.0
-        resources:
-          request:
-            memory: '100Mi'
-            cpu: 100m
-          limit:
-            memory: '100Mi'
-            cpu: 100m
       - name: app-served-{{ .ns }}
         imagePullPolicy: IfNotPresent
         image: rhscl/httpd-24-rhel7:latest

--- a/objectTemplates/cluster_density_pod_served.yml
+++ b/objectTemplates/cluster_density_pod_served.yml
@@ -10,13 +10,6 @@ spec:
   - name: sleep-1
     imagePullPolicy: IfNotPresent
     image: gcr.io/google_containers/pause-amd64:3.0
-    resources:
-      request:
-        memory: '100Mi'
-        cpu: 100m
-      limit:
-        memory: '100Mi'
-        cpu: 100m
   - name: app-served-{{ .ns }}
     imagePullPolicy: IfNotPresent
     image: rhscl/httpd-24-rhel7:latest

--- a/objectTemplates/node_density_pod_served.yml
+++ b/objectTemplates/node_density_pod_served.yml
@@ -18,14 +18,7 @@ spec:
       periodSeconds: 30
       failureThreshold: 1
       timeoutSeconds: 15
-      initialDelaySeconds: 5
-    resources:
-      request:
-        memory: '100Mi'
-        cpu: 100m
-      limit:
-        memory: '100Mi'
-        cpu: 100m          
+      initialDelaySeconds: 5       
     ports:
     - containerPort: 8080        
   - args:
@@ -33,14 +26,7 @@ spec:
     - infinity
     name: app
     image: k8s.gcr.io/pause:3.1
-    imagePullPolicy: IfNotPresent
-    resources:
-      request:
-        memory: '100Mi'
-        cpu: 100m
-      limit:
-        memory: '100Mi'
-        cpu: 100m   
+    imagePullPolicy: IfNotPresent  
       #  nodeSelector:
       #     kubernetes.io/hostname: worker{{if eq .Iteration 81}}{{printf "%03d" (add .Iteration 2)}}{{else if eq .Iteration 82}}{{printf "%03d" (add .Iteration 1)}}{{else if eq .Iteration 98}}{{printf "%03d" (add .Iteration 2)}}{{else if eq .Iteration 110}}{{printf "%03d" (add .Iteration 2)}}{{else}}{{printf "%03d" (add .Iteration 3)}}{{end}}-r640   
   affinity:

--- a/objectTemplates/node_density_pod_served_f5.yml
+++ b/objectTemplates/node_density_pod_served_f5.yml
@@ -10,13 +10,6 @@ spec:
   - name: sleep-1
     imagePullPolicy: IfNotPresent
     image: gcr.io/google_containers/pause-amd64:3.0
-    resources:
-      request:
-        memory: '100Mi'
-        cpu: 100m
-      limit:
-        memory: '100Mi'
-        cpu: 100m
   - name: f5-f5-served-ns-{{ .ns }}-{{ .Replica }}
     imagePullPolicy: IfNotPresent
     image: rhscl/httpd-24-rhel7:latest

--- a/workload/cfg_icni2_node_density2.yml
+++ b/workload/cfg_icni2_node_density2.yml
@@ -19,7 +19,7 @@ jobs:
     burst: {{ $.BURST }}
     namespacedIterations: false
     cleanup: false
-    namespace: served-ns-{{ $val }}
+    namespace: served-ns-{{ (sub $val 1|int) }}
     podWait: false
     waitWhenFinished: false
     verifyObjects: true
@@ -40,7 +40,7 @@ jobs:
     burst: {{ $.BURST }}
     namespacedIterations: false
     cleanup: false
-    namespace: served-ns-{{ $val }}
+    namespace: served-ns-{{ (sub $val 1|int) }}
     podWait: true
     waitWhenFinished: true
     verifyObjects: true
@@ -65,7 +65,7 @@ jobs:
     burst: {{ $.BURST }}
     namespacedIterations: false
     cleanup: false
-    namespace: served-ns-{{ $val }}
+    namespace: served-ns-{{ (sub $val 1|int) }}
     podWait: false
     waitWhenFinished: false
     verifyObjects: true
@@ -87,7 +87,7 @@ jobs:
     burst: {{ $.BURST }}
     namespacedIterations: false
     cleanup: false
-    namespace: served-ns-{{ $val }}
+    namespace: served-ns-{{ (sub $val 1|int) }}
     podWait: true
     waitWhenFinished: true
     verifyObjects: true
@@ -110,7 +110,7 @@ jobs:
     burst: {{ .BURST }}
     namespacedIterations: false
     cleanup: false
-    namespace: served-ns-{{ $servedLimit }}
+    namespace: served-ns-{{ (sub $servedLimit 1|int) }}
     podWait: true
     waitWhenFinished: true
     verifyObjects: true


### PR DESCRIPTION
When kube-burner moved to [sprig](http://masterminds.github.io/sprig) as the new golang templating language namespaced workloads started on -0 instead on -1.
This PR accounts for that in non-namespaced workloads.