### PR TITLE
Proper non-SRIOV cleaning

### DIFF
--- a/workload/cfg_delete_icni2_serving_resource.yml
+++ b/workload/cfg_delete_icni2_serving_resource.yml
@@ -15,9 +15,11 @@ jobs:
         kind: Deployment
         labelSelector: {kube-burner-job: serving-job}
 
+      {{ if contains .SRIOV "true" }}
       - apiVersion: sriovnetwork.openshift.io/v1
         kind: SriovNetwork
         labelSelector: {kube-burner-job: create-networks-job}
+      {{ end }}
 
       - apiVersion: v1
         kind: Configmap


### PR DESCRIPTION
@Harshith-umesh  found an issue with the cleaning/deleting script when running web-burner without sriov interfaces (i.e.: macvlan network attachment definitions).
This PR corrects this issue.