### PR TITLE
[DO NOT MERGE] spread pods across zones

### DIFF
--- a/create_icni2_workload.sh
+++ b/create_icni2_workload.sh
@@ -106,6 +106,6 @@ sleep 60 # sleep for a minute before actual workload
 
 
 echo "Lets create ICNI2 workloads..$uuid"
-kube-burner init -c ${1} -t ${token} --uuid $(uuidgen) --prometheus-url https://${prometheus_url} -m workload/metrics_full.yml
+kube-burner init -c ${1} -t ${token} --uuid $(uuidgen) --prometheus-url https://${prometheus_url} -m workload/metrics.yml
 
 

--- a/objectTemplates/node_density_pod_served-zone-a.yml
+++ b/objectTemplates/node_density_pod_served-zone-a.yml
@@ -55,7 +55,7 @@ spec:
             operator: DoesNotExist
   topologySpreadConstraints:
   - maxSkew: 1
-    topologyKey: kubernetes.io/hostname
+    topologyKey: topologySpreadConstraints-zone-A
     whenUnsatisfiable: ScheduleAnyway
     labelSelector:
       matchLabels:

--- a/objectTemplates/node_density_pod_served-zone-b.yml
+++ b/objectTemplates/node_density_pod_served-zone-b.yml
@@ -55,7 +55,7 @@ spec:
             operator: DoesNotExist
   topologySpreadConstraints:
   - maxSkew: 1
-    topologyKey: kubernetes.io/hostname
+    topologyKey: topologySpreadConstraints-zone-B
     whenUnsatisfiable: ScheduleAnyway
     labelSelector:
       matchLabels:

--- a/workload/cfg_icni2_node_density2.yml
+++ b/workload/cfg_icni2_node_density2.yml
@@ -32,6 +32,7 @@ jobs:
         replicas: 1
 {{ end }}
 
+{{- $zoneA := div $normalLimit 2 }}
 {{ range $index, $val := untilStep 1 (add $normalLimit 1|int) 1 }}
   - name: normal-job-{{ $val }}
     jobType: create
@@ -49,7 +50,11 @@ jobs:
     jobPause: 0s
     preLoadImages: false
     objects:
-      - objectTemplate: objectTemplates/node_density_pod_served.yml
+      {{- if gt $index $zoneA}}
+      - objectTemplate: objectTemplates/node_density_pod_served-zone-b.yml
+      {{- else }}
+      - objectTemplate: objectTemplates/node_density_pod_served-zone-a.yml
+      {{- end }}
         replicas: 60
         inputVars:
           probe: "{{ $.PROBE }}"

--- a/workload/metrics.yml
+++ b/workload/metrics.yml
@@ -1,0 +1,160 @@
+# API server
+
+- query: irate(apiserver_request_total{verb="POST", resource="pods", subresource="binding",code="201"}[2m]) > 0
+  metricName: schedulingThroughput
+
+- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb=~"LIST|GET", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope)) > 0
+  metricName: readOnlyAPICallsLatency
+
+- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb=~"POST|PUT|DELETE|PATCH", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope)) > 0
+  metricName: mutatingAPICallsLatency
+
+- query: sum(irate(apiserver_request_total{apiserver="kube-apiserver",verb!="WATCH"}[2m])) by (verb,resource,code) > 0
+  metricName: APIRequestRate
+
+# Kubeproxy and OVN service sync latency
+
+- query: histogram_quantile(0.99, sum(rate(kubeproxy_network_programming_duration_seconds_bucket[2m])) by (le)) > 0
+  metricName: serviceSyncLatency
+
+- query: histogram_quantile(0.99, sum(rate(ovnkube_master_network_programming_duration_seconds_bucket{kind="service"}[2m])) by (le))
+  metricName: serviceSyncLatency
+
+# Containers & pod metrics
+
+- query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!~"POD|",namespace=~"openshift-(etcd|.*apiserver|ovn-kubernetes|network-node-identity|multus|sdn|ingress|.*controller-manager|.*scheduler)"}[2m]) * 100) by (container, pod, namespace, node)) > 0
+  metricName: containerCPU
+
+- query: sum(container_memory_rss{name!="",container!~"POD|",namespace=~"openshift-(etcd|.*apiserver|ovn-kubernetes|network-node-identity|multus|sdn|ingress|.*controller-manager|.*scheduler)"}) by (container, pod, namespace, node)
+  metricName: containerMemory
+
+# Kubelet & CRI-O runtime metrics
+
+- query: sum(irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[2m]) * 100) by (node) and on (node) kube_node_role{role="worker"}
+  metricName: kubeletCPU
+
+- query: sum(process_resident_memory_bytes{service="kubelet",job="kubelet"}) by (node) and on (node) kube_node_role{role="worker"}
+  metricName: kubeletMemory
+
+- query: sum(irate(process_cpu_seconds_total{service="kubelet",job="crio"}[2m]) * 100) by (node) and on (node) kube_node_role{role="worker"}
+  metricName: crioCPU
+
+- query: sum(process_resident_memory_bytes{service="kubelet",job="crio"}) by (node) and on (node) kube_node_role{role="worker"}
+  metricName: crioMemory
+
+- query: irate(container_runtime_crio_operations_latency_microseconds{operation_type="network_setup_pod"}[2m]) > 0
+  metricName: containerNetworkSetupLatency
+
+# Node metrics: CPU & Memory
+
+- query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) > 0
+  metricName: nodeCPU-Workers
+
+- query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) > 0
+  metricName: nodeCPU-Masters
+
+- query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
+  metricName: nodeCPU-Infra
+
+# We compute memory utilization by substrating available memory to the total
+
+- query: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryUtilization-Masters
+
+- query: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryUtilization-Workers
+
+- query: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryUtilization-Infra
+
+# Etcd metrics
+
+- query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
+  metricName: etcdLeaderChangesRate
+
+- query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))
+  metricName: 99thEtcdDiskBackendCommitDurationSeconds
+
+- query: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[2m]))
+  metricName: 99thEtcdDiskWalFsyncDurationSeconds
+
+- query: histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket[5m]))
+  metricName: 99thEtcdRoundTripTimeSeconds
+
+- query: sum by (cluster_version)(etcd_cluster_version)
+  metricName: etcdVersion
+  instant: true
+
+# Cluster metrics
+
+- query: sum(kube_namespace_status_phase) by (phase) > 0
+  metricName: namespaceCount
+
+- query: sum(kube_pod_status_phase{}) by (phase)
+  metricName: podStatusCount
+
+- query: count(kube_secret_info{})
+  metricName: secretCount
+  instant: true
+
+- query: count(kube_deployment_labels{})
+  metricName: deploymentCount
+  instant: true
+
+- query: count(kube_configmap_info{})
+  metricName: configmapCount
+  instant: true
+
+- query: count(kube_service_info{})
+  metricName: serviceCount
+  instant: true
+
+- query: kube_node_role
+  metricName: nodeRoles
+
+- query: sum(kube_node_status_condition{status="true"}) by (condition)
+  metricName: nodeStatus
+
+- query: count(kube_replicaset_labels{})
+  metricName: replicaSetCount
+  instant: true
+
+- query: count(kube_pod_info{} AND ON (pod) kube_pod_status_phase{phase="Running"}==1) by (node)
+  metricName: podDistribution
+
+# Prometheus metrics
+
+- query: openshift:prometheus_tsdb_head_series:sum{job="prometheus-k8s"}
+  metricName: prometheus-timeseriestotal
+
+- query: openshift:prometheus_tsdb_head_samples_appended_total:sum{job="prometheus-k8s"}
+  metricName: prometheus-ingestionrate
+
+# Retain the raw CPU seconds totals for comparison
+- query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="worker",role!="infra"}, "instance", "$1", "node", "(.+)") ) by (mode)
+  metricName: nodeCPUSeconds-Workers
+  instant: true
+
+- query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)") ) by (mode)
+  metricName: nodeCPUSeconds-Masters
+  instant: true
+
+- query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)") ) by (mode)
+  metricName: nodeCPUSeconds-Infra
+  instant: true
+
+- query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" } and on (node) kube_node_role{ role = "worker",role != "infra" } )  by   (   id  )
+  metricName: cgroupCPUSeconds-Workers
+  instant: true
+
+- query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }  and on (node) kube_node_role{ role = "master" } )  by   (   id  )
+  metricName: cgroupCPUSeconds-Masters
+  instant: true
+
+- query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }  and on (node) kube_node_role{ role = "infra" } )  by   (   id  )
+  metricName: cgroupCPUSeconds-Infra
+  instant: true
+
+- query: sum( container_cpu_usage_seconds_total{container!~"POD|",namespace=~"openshift-.*"} )  by (namespace)
+  metricName: cgroupCPUSeconds-namespaces
+  instant: true


### PR DESCRIPTION
This patch uses topologySpreadConstraints to spread pods across nodes.

This patch creates zone as label on worker nodes. First 60 workers should be manually labeled to zone-A and next workers to zone-B oc label node worker008-fc640 topologySpreadConstraints-zone-A="" ..
oc label node worker056-fc640 topologySpreadConstraints-zone-A="" oc label node worker057-fc640 topologySpreadConstraints-zone-B="" ..
oc label node worker116-fc640 topologySpreadConstraints-zone-B=""

Then out 35 namespaces, pods belonging to namespaces 1 to 17 will be hosted in zone-A workers i.e workers 8 to 60. Then pods belonging to namespaces 18 to 35 will be hosted in zone-B workers i.e workers 61 to 120
This way we can distribute pods to workers uniformely