### PR TITLE
Support the non ICNI pod annotations support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,12 @@ on:
     branches: [ "*" ]
     paths-ignore:
     - '**.md'
+    - '**.sh'
   pull_request:
     branches: [ "*" ]
     paths-ignore:
     - '**.md'
+    - '**.sh'
   schedule:
     - cron: 0 3 * * *
 

--- a/.github/workflows/ci_bfd.yml
+++ b/.github/workflows/ci_bfd.yml
@@ -5,10 +5,12 @@ on:
     branches: [ "*" ]
     paths-ignore:
     - '**.md'
+    - '**.sh'
   pull_request:
     branches: [ "*" ]
     paths-ignore:
     - '**.md'
+    - '**.sh'
   schedule:
     - cron: 0 3 * * *
 

--- a/.github/workflows/ci_bfd_crd.yml
+++ b/.github/workflows/ci_bfd_crd.yml
@@ -5,10 +5,12 @@ on:
     branches: [ "*" ]
     paths-ignore:
     - '**.md'
+    - '**.sh'
   pull_request:
     branches: [ "*" ]
     paths-ignore:
     - '**.md'
+    - '**.sh'
   schedule:
     - cron: 0 3 * * *
 

--- a/.github/workflows/ci_crd.yml
+++ b/.github/workflows/ci_crd.yml
@@ -5,10 +5,12 @@ on:
     branches: [ "*" ]
     paths-ignore:
     - '**.md'
+    - '**.sh'
   pull_request:
     branches: [ "*" ]
     paths-ignore:
     - '**.md'
+    - '**.sh'
   schedule:
     - cron: 0 3 * * *
 

--- a/README.md
+++ b/README.md
@@ -217,19 +217,19 @@ OS/Arch: linux amd64
 
 Export the following variables:
 ```
-$ export BFD=${BFD:-false}
-$ export BRIDGE=breth0
-$ export BURST=${BURST:-20}
-$ export CRD=false
-$ export ES_INDEX=""
-$ export ES_SERVER=""
-$ export ICNI=true
-$ export INDEXING=""
-$ export LIMITCOUNT=1
-$ export PROBE=true
-$ export QPS=${QPS:-20}
-$ export SCALE=${SCALE:-1}
-$ export SRIOV=false
+export BFD=${BFD:-false}
+export BRIDGE=breth0
+export BURST=${BURST:-20}
+export CRD=false
+export ES_INDEX=""
+export ES_SERVER=""
+export ICNI=true
+export INDEXING=""
+export LIMITCOUNT=1
+export PROBE=true
+export QPS=${QPS:-20}
+export SCALE=${SCALE:-1}
+export SRIOV=false
 ```
 
 Create the load balancing/serving resources (took 2m):
@@ -368,19 +368,19 @@ $ kubectl get po -A | grep served | grep Running | wc -l
 
 Export the following variables:
 ```
-$ export BFD=true
-$ export BRIDGE=breth0
-$ export BURST=${BURST:-20}
-$ export CRD=false
-$ export ES_INDEX=""
-$ export ES_SERVER=""
-$ export ICNI=true
-$ export INDEXING=""
-$ export LIMITCOUNT=1
-$ export PROBE=true
-$ export QPS=${QPS:-20}
-$ export SCALE=${SCALE:-1}
-$ export SRIOV=false
+export BFD=true
+export BRIDGE=breth0
+export BURST=${BURST:-20}
+export CRD=false
+export ES_INDEX=""
+export ES_SERVER=""
+export ICNI=true
+export INDEXING=""
+export LIMITCOUNT=1
+export PROBE=true
+export QPS=${QPS:-20}
+export SCALE=${SCALE:-1}
+export SRIOV=false
 ```
 
 Create the load balancing/serving resources (took 2m):
@@ -637,16 +637,19 @@ $ cd web-burner
 
 Export the following variables:
 ```
-$ export BFD=${BFD:-false}
-$ export BRIDGE=${BRIDGE:-br-ex}
-$ export BURST=${BURST:-20}
-$ export ES_INDEX=${ES_INDEX:-ripsaw-kube-burner}
-$ export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com}
-$ export LIMITCOUNT=1
-$ export PROBE=false
-$ export QPS=${QPS:-20}
-$ export SCALE=${SCALE:-1}
-$ export SRIOV=false
+export BFD=${BFD:-false}
+export BRIDGE=${BRIDGE:-br-ex}
+export BURST=${BURST:-20}
+export CRD=false
+export ES_INDEX=${ES_INDEX:-ripsaw-kube-burner}
+export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com}
+export ICNI=true
+export INDEXING=""
+export LIMITCOUNT=1
+export PROBE=false
+export QPS=${QPS:-20}
+export SCALE=${SCALE:-1}
+export SRIOV=false
 ```
 
 Make sure kube-burner is installed in the appropiate version:

--- a/create_icni2_workload.sh
+++ b/create_icni2_workload.sh
@@ -9,7 +9,7 @@ export BURST=${BURST:-20}
 export CRD=${CRD:=false}          # use the new AdminPolicyBasedExternalRoute instead of the legacy pod/ns annotations
 export ES_INDEX=${ES_INDEX:-ripsaw-kube-burner}
 export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com}
-export ICNI=${ICNI:=true}         # enable or disable ICNI functionality. Requires CRD=true and PROBE=false
+export ICNI=${ICNI:=true}         # enable or disable ICNI functionality. Requires PROBE=false
 export INDEXING=${INDEXING:-elastic}
 export KUBE_BURNER_RELEASE=${KUBE_BURNER_RELEASE:-1.7.12}
 #The limit count is used to calculate servedlimit and normallimit. For a 120 node cluster the default count is 35, for other size clusters use this formula to calculate. limit count = (35 * cluster_size) // 120

--- a/objectTemplates/node_density_pod_served.yml
+++ b/objectTemplates/node_density_pod_served.yml
@@ -18,9 +18,9 @@ spec:
       periodSeconds: 30
       failureThreshold: 1
       timeoutSeconds: 15
-      initialDelaySeconds: 5       
+      initialDelaySeconds: 5
     ports:
-    - containerPort: 8080        
+    - containerPort: 8080
   - args:
     - sleep
     - infinity

--- a/objectTemplates/pod_serving.yml
+++ b/objectTemplates/pod_serving.yml
@@ -12,8 +12,13 @@ spec:
       annotations:
         {{ if contains .crd "false" }}
         gateway-ip: "192.168.{{ add 218 .Replica }}.{{ add 1 .Iteration }}"
+        {{ if contains .icni "true" }}
         k8s.ovn.org/routing-namespaces: served-ns-{{ .Iteration }}
         k8s.ovn.org/routing-network: serving-ns-{{ .Iteration }}/sriov-net-{{ .Iteration }}
+        {{ else }}
+        k8s.ovn.org/routing-namespaces: nonexisting-ns-{{ .Iteration }}
+        k8s.ovn.org/routing-network: nonexisting-ns-{{ .Iteration }}/sriov-net-{{ .Iteration }}
+        {{ end }}
         {{ if contains .bfd "true" }}
         k8s.ovn.org/bfd-enabled: ""
         {{ end }}

--- a/workload/cfg_icni2_serving_resource_init.yml
+++ b/workload/cfg_icni2_serving_resource_init.yml
@@ -190,3 +190,4 @@ jobs:
         inputVars:
           crd: "{{ $.CRD }}"
           bfd: "{{ $.BFD }}"
+          icni: "{{ $.ICNI }}"


### PR DESCRIPTION
https://github.com/redhat-performance/web-burner/pull/80 introduced a new flag to disable the ICNI functionality, but limited to the CRD scenario.
This PR extends the support for the non CRD scenario (serving pod annotations).